### PR TITLE
Fix onKeyPress handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -158,8 +158,13 @@ Prompt.prototype.coerceToRange = function() {
  */
 
 Prompt.prototype.onKeypress = function(e) {
-  var keypress = e.key && e.key.name;
+  var keypress = e;
   var len = this.currentChoices.length;
+
+  // Let onSubmit handle return key press
+  if (e === 'return') {
+    return;
+  }
 
   if (keypress === 'down') {
     this.selected = (this.selected < len - 1) ? this.selected + 1 : 0;

--- a/index.js
+++ b/index.js
@@ -157,12 +157,11 @@ Prompt.prototype.coerceToRange = function() {
  * When user types
  */
 
-Prompt.prototype.onKeypress = function(e) {
-  var keypress = e;
+Prompt.prototype.onKeypress = function(keypress) {
   var len = this.currentChoices.length;
 
   // Let onSubmit handle return key press
-  if (e === 'return') {
+  if (keypress === 'return') {
     return;
   }
 


### PR DESCRIPTION
The event received by the `onKeyPress` is now the key name. 

`onKeyPress` also receive a key press event for the `return` key which led to a conflict between the `onSubmit` and the `search` methods.
